### PR TITLE
Add configuration flag to force the processing of duplicate events

### DIFF
--- a/src/k8s.Operators/Controller.cs
+++ b/src/k8s.Operators/Controller.cs
@@ -29,7 +29,7 @@ namespace k8s.Operators
             this._client = client;
             this._logger = loggerFactory?.CreateLogger<Controller<T>>() ?? SilentLogger.Instance;
             this._eventManager = new EventManager(loggerFactory);
-            this._changeTracker = new ResourceChangeTracker(loggerFactory);
+            this._changeTracker = new ResourceChangeTracker(configuration, loggerFactory);
             this._crd = (CustomResourceDefinitionAttribute) Attribute.GetCustomAttribute(typeof(T), typeof(CustomResourceDefinitionAttribute));
             this.RetryPolicy = configuration.RetryPolicy;
         }

--- a/src/k8s.Operators/Models/OperatorConfiguration.cs
+++ b/src/k8s.Operators/Models/OperatorConfiguration.cs
@@ -8,7 +8,7 @@ namespace k8s.Operators
         /// <summary>
         /// Returns the default configuration.
         /// </summary>
-        public static OperatorConfiguration Default = new OperatorConfiguration();
+        public static OperatorConfiguration Default = new OperatorConfiguration(); // TODO: make readonly
 
         /// <summary>
         /// The namespace to watch. Set to empty string to watch all namespaces.
@@ -24,5 +24,10 @@ namespace k8s.Operators
         /// The retry policy for the event handling.
         /// </summary>
         public RetryPolicy RetryPolicy { get; set; } = new RetryPolicy();
+
+        /// <summary>
+        /// If true, discards the event whose spec generation has already been received and processed
+        /// </summary>
+        public bool DiscardDuplicateSpecGenerations { get; set; } = true;
     }
 }


### PR DESCRIPTION
Closes #6

By default, `ResourceChangeTracker` discards an event if the spec generation has already been received and processed in the past.

A configuration flag `DiscardDuplicateSpecGenerations` has been added (defaulted to true).

Set `OperatorConfiguration.DiscardDuplicateSpecGenerations = false` to force a controller to process duplicate resource generations.